### PR TITLE
fix: special casing for Psalms

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -23,6 +23,8 @@
    - Every `photo.Descriptor` should define an image for the `photo.Original` key, which should provide a full-size, original image.
    - The `photo.FromImage` option has been added for use with the `ResizeImage` method of `photo.Service`, which selects which `photo.Image` associated with a `photo.Descriptor` should be used as the source image for resizing.
  * New utility function `unsplash.IDFromURL()` added which will give you the photo ID from an Unsplash photo URL.
+ * :hammer: Fix: Multiple total chapter references will be resolved to chapter ranges. For example, if you parse "Ps. 12-13", the resolver will correctly return "Psalms 12-13" instead of "Psalms 12:1-13:6" as it would have before.
+ * :hammer: Fix: Psalms singular handling has been special cased so that references to a single verse can show something like "Psalm 12" or "Psalm 12:1-3" rather than "Psalms 12" or "Psalms 12:1-3" as it would have before.
 
 ## 0.5.1  2024-02-20
 

--- a/pkg/ref/abbr.go
+++ b/pkg/ref/abbr.go
@@ -201,6 +201,7 @@ var Abbreviations = &BookAbbreviations{
 		{
 			Name:      "Psalms",
 			Preferred: "Ps.",
+			Singular:  "Psalm",
 			Accepts: []string{
 				"Psalms",
 				"Pslm",

--- a/pkg/ref/books_test.go
+++ b/pkg/ref/books_test.go
@@ -665,6 +665,21 @@ func TestBookAbbreviations_BookName(t *testing.T) {
 	assert.ErrorIs(t, err, ref.ErrNotFound)
 }
 
+func TestBookAbbreviations_SingularName(t *testing.T) {
+	t.Parallel()
+
+	sname, err := ref.Abbreviations.SingularName("John")
+	assert.NoError(t, err)
+	assert.Equal(t, "John", sname)
+
+	sname, err = ref.Abbreviations.SingularName("Psalms")
+	assert.NoError(t, err)
+	assert.Equal(t, "Psalm", sname)
+
+	_, err = ref.Abbreviations.SingularName("Psalm")
+	assert.ErrorIs(t, err, ref.ErrNotFound)
+}
+
 func TestBookAbbreviations_PreferredAbbreviation(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/ref/ref_test.go
+++ b/pkg/ref/ref_test.go
@@ -420,6 +420,10 @@ func TestResolved_CompactRef(t *testing.T) {
 	require.NotNil(t, gen)
 	require.NoError(t, err)
 
+	psa, err := ref.Canonical.Book("Psalms")
+	require.NotNil(t, psa)
+	require.NoError(t, err)
+
 	cr, err := (&ref.Resolved{
 		Book:  gen,
 		First: ref.CV{Chapter: 12, Verse: 4},
@@ -464,4 +468,22 @@ func TestResolved_CompactRef(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, "Genesis 12:4-13:1", cr)
+
+	cr, err = (&ref.Resolved{
+		Book:  psa,
+		First: ref.CV{Chapter: 12, Verse: 1},
+		Last:  ref.CV{Chapter: 12, Verse: 8},
+	}).CompactRef()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "Psalm 12", cr)
+
+	cr, err = (&ref.Resolved{
+		Book:  psa,
+		First: ref.CV{Chapter: 12, Verse: 1},
+		Last:  ref.CV{Chapter: 13, Verse: 6},
+	}).CompactRef()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "Psalms 12-13", cr)
 }

--- a/tools/gen/verses/abbr.yaml
+++ b/tools/gen/verses/abbr.yaml
@@ -118,6 +118,7 @@ books:
       - Jb
   - name: Psalms
     standard: Ps.
+    singular: Psalm
     accept:
       - Psalms
       - Pslm

--- a/tools/gen/verses/abbrs.go.tmpl
+++ b/tools/gen/verses/abbrs.go.tmpl
@@ -6,6 +6,9 @@ var Abbreviations = &BookAbbreviations{
         {
             Name: "{{.Name}}",
             Preferred: "{{.Standard}}",
+{{- if .Singular}}
+            Singular: "{{.Singular}}",
+{{- end }}
 {{- if .Ordinal}}
             Ordinal: {{.Ordinal}},
 {{- end}}

--- a/tools/gen/verses/main.go
+++ b/tools/gen/verses/main.go
@@ -43,6 +43,7 @@ type OrdinalConfig struct {
 type BookAbbrConfig struct {
 	Name     string   `yaml:"name"`
 	Standard string   `yaml:"standard"`
+	Singular string   `yaml:"singular"`
 	Ordinal  string   `yaml:"ordinal"`
 	Accept   []string `yaml:"accept"`
 }


### PR DESCRIPTION
* Adds special casing for singular Psalm references.
* Fixes handling of multiple full chapter references generated by `CompactRef`