### PR TITLE
feat: better category list, now lists pericopes

### DIFF
--- a/cmd/categories.go
+++ b/cmd/categories.go
@@ -2,21 +2,48 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/spf13/cobra"
+	"github.com/zostay/go-std/maps"
 
 	"github.com/zostay/today/pkg/ref"
 )
 
-var listCategoriesCmd = &cobra.Command{
-	Use:   "categories",
-	Short: "List the available categories",
-	Args:  cobra.NoArgs,
-	Run:   RunListCategories,
+var (
+	listCategoriesCmd = &cobra.Command{
+		Use:   "categories",
+		Short: "List the available categories",
+		Args:  cobra.NoArgs,
+		Run:   RunListCategories,
+	}
+
+	listPericopes bool
+)
+
+func init() {
+	listCategoriesCmd.Flags().BoolVarP(&listPericopes, "pericopes", "p", false, "List the pericopes in each category")
 }
 
 func RunListCategories(cmd *cobra.Command, args []string) {
-	for c := range ref.Canonical.Categories {
+	cats := maps.Keys(ref.Canonical.Categories)
+	sort.Strings(cats)
+
+	for _, c := range cats {
 		fmt.Println(c)
+		if listPericopes {
+			ps, err := ref.Canonical.Category(c)
+			if err != nil {
+				panic(err)
+			}
+
+			sort.Slice(ps, func(i, j int) bool {
+				return ps[i].Ref.Ref() < ps[j].Ref.Ref()
+			})
+
+			for _, p := range ps {
+				fmt.Printf("  %s\n", p.Ref.Ref())
+			}
+		}
 	}
 }


### PR DESCRIPTION
This pull request includes changes to the `cmd/categories.go` file to enhance the functionality of the `listCategoriesCmd` command. The most important changes include adding a new flag to list pericopes within categories and sorting categories and pericopes for better readability.

Enhancements to `listCategoriesCmd` command:

* Added `sort` and `maps` packages to manage and sort categories and pericopes. (`cmd/categories.go`)
* Introduced a new boolean flag `--pericopes` to list the pericopes within each category. (`cmd/categories.go`)
* Modified `RunListCategories` function to sort categories and pericopes before printing them. (`cmd/categories.go`)