### PR TITLE
fix: verse subtraction

### DIFF
--- a/pkg/ref/ref.go
+++ b/pkg/ref/ref.go
@@ -821,7 +821,7 @@ func (r *Resolved) Subtract(s *Resolved) []Resolved {
 		return []Resolved{}
 
 	// subtracted is at the start of the original, return original without start
-	case vCmp(r.First, s.First) == 0 && vCmp(r.Last, s.Last) >= 0:
+	case vCmp(r.First, s.First) >= 0 && vCmp(r.First, s.Last) <= 0 && vCmp(r.Last, s.Last) >= 0:
 		var firstVerse Verse
 		for _, v := range r.Verses() {
 			if s.Last.Before(v) {
@@ -839,7 +839,7 @@ func (r *Resolved) Subtract(s *Resolved) []Resolved {
 		}
 
 	// subtracted is at the end of the original, return original without end
-	case vCmp(r.First, s.First) <= 0 && vCmp(r.Last, s.Last) == 0:
+	case vCmp(r.First, s.First) <= 0 && vCmp(r.Last, s.First) >= 0 && vCmp(r.Last, s.Last) <= 0:
 		var lastVerse Verse
 		for _, v := range r.Verses() {
 			if v.Equal(s.First) {


### PR DESCRIPTION
This fixes the issue in #43 

This pull request includes changes to the `Subtract` method in the `Resolved` struct to refine the logic for handling verse comparisons. The most important changes involve updating the conditions for subtracting verses at the start and end of the original set.

Refinements to verse comparison logic:

* [`pkg/ref/ref.go`](diffhunk://#diff-71df93026f1fb2f55aa6926f3ebdd60caa493128f445bad592ebc1721a175f87L824-R824): Modified the condition to handle cases where the subtracted verse is at the start of the original set. The new condition ensures that the first verse of the original is greater than or equal to the first verse of the subtracted set, and the last verse of the original is greater than or equal to the last verse of the subtracted set.
* [`pkg/ref/ref.go`](diffhunk://#diff-71df93026f1fb2f55aa6926f3ebdd60caa493128f445bad592ebc1721a175f87L842-R842): Updated the condition to handle cases where the subtracted verse is at the end of the original set. The new condition ensures that the first verse of the original is less than or equal to the first verse of the subtracted set, and the last verse of the original is less than or equal to the last verse of the subtracted set.