### PR TITLE
fix: panic when Daniel 6:1-7:19 is excluded

### DIFF
--- a/pkg/ref/pericope.go
+++ b/pkg/ref/pericope.go
@@ -13,7 +13,7 @@ type Pericope struct {
 func Lookup(c *Canon, ref, title string) (*Pericope, error) {
 	p, err := ParseProper(ref)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error parsing ref %q: %w", ref, err)
 	}
 
 	if !p.IsSingleRange() {
@@ -22,7 +22,7 @@ func Lookup(c *Canon, ref, title string) (*Pericope, error) {
 
 	res, err := c.Resolve(p)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error resolving reference %q: %w", p.Ref(), err)
 	}
 
 	return &Pericope{

--- a/pkg/ref/random.go
+++ b/pkg/ref/random.go
@@ -87,7 +87,7 @@ func Random(opt ...RandomReferenceOption) (*Resolved, error) {
 	if len(o.exclude) > 0 {
 		o.canon, err = o.canon.Filtered(o.exclude...)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error while filtering for requested verses: %w", err)
 		}
 	}
 
@@ -114,7 +114,7 @@ func Random(opt ...RandomReferenceOption) (*Resolved, error) {
 
 		ps, err := o.canon.Category(o.category)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error getting category pericopes %q: %w", o.category, err)
 		}
 
 		// lazy way to weight the books by the number of verses they have
@@ -132,7 +132,7 @@ func Random(opt ...RandomReferenceOption) (*Resolved, error) {
 		if o.book != "" {
 			ex, err := Lookup(Canonical, o.book+" 1:1ffb", "")
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("error looking up book %q: %w", o.book, err)
 			}
 
 			b = ex.Ref.Book

--- a/pkg/text/service.go
+++ b/pkg/text/service.go
@@ -3,6 +3,7 @@ package text
 import (
 	"context"
 	"errors"
+	"fmt"
 	"html/template"
 
 	"github.com/zostay/today/pkg/ref"
@@ -119,19 +120,27 @@ func (s *Service) RandomVerse(ctx context.Context, opt ...ref.RandomReferenceOpt
 func (s *Service) RandomVerseText(ctx context.Context, opt ...ref.RandomReferenceOption) (*ref.Resolved, string, error) {
 	res, err := ref.Random(opt...)
 	if err != nil {
-		return nil, "", err
+		return nil, "", fmt.Errorf("unable to select random verse: %w", err)
 	}
 
 	txt, err := s.Resolver.VerseText(ctx, res)
-	return res, txt, err
+	if err != nil {
+		return res, txt, fmt.Errorf("unable to resolve text for verse %q: %w", res.Ref(), err)
+	}
+
+	return res, txt, nil
 }
 
 func (s *Service) RandomVerseHTML(ctx context.Context, opt ...ref.RandomReferenceOption) (*ref.Resolved, template.HTML, error) {
 	res, err := ref.Random(opt...)
 	if err != nil {
-		return nil, "", err
+		return nil, "", fmt.Errorf("unable to select random verse: %w", err)
 	}
 
 	txt, err := s.Resolver.VerseHTML(ctx, res)
-	return res, txt, err
+	if err != nil {
+		return res, txt, fmt.Errorf("unable to resolve HTML for verse %q: %w", res.Ref(), err)
+	}
+
+	return res, txt, nil
 }


### PR DESCRIPTION
The primary fix here is that during `Lookup`, the tooling is less panicky when it encounters a chapter reference for a chapter that doesn't start with verse 1. This does not occur in the ESV as far as I'm aware, but John 7:53-8:11 is a close miss. It is possible that a Bible version exists which omits this passage or has moved it somewhere else due to it not being part of the most ancient manuscripts. As the modules here provide a means for creating such canons, we should support them.

This pull request also works on improving error handling by adding more descriptive error messages across various functions in the codebase. These changes enhance the clarity of error reporting, making it easier to debug issues when they arise.

Improvements to error handling:

* [`pkg/ref/books.go`](diffhunk://#diff-03e24686f7dafec110d5283377ef5a3c84075639a4963ba3006823a7ae25b6bbL93-R93): Enhanced error messages in the `Category` and `ensureVerseMatchesBook` functions to include more context about the failures. [[1]](diffhunk://#diff-03e24686f7dafec110d5283377ef5a3c84075639a4963ba3006823a7ae25b6bbL93-R93) [[2]](diffhunk://#diff-03e24686f7dafec110d5283377ef5a3c84075639a4963ba3006823a7ae25b6bbR264-R280)
* [`pkg/ref/pericope.go`](diffhunk://#diff-18328172d42f9fb8f42c3d1618e005d79e4ee0dc6b69d079682c10780ab76c07L16-R16): Updated the `Lookup` function to provide more detailed error messages when parsing and resolving references fail. [[1]](diffhunk://#diff-18328172d42f9fb8f42c3d1618e005d79e4ee0dc6b69d079682c10780ab76c07L16-R16) [[2]](diffhunk://#diff-18328172d42f9fb8f42c3d1618e005d79e4ee0dc6b69d079682c10780ab76c07L25-R25)
* [`pkg/ref/random.go`](diffhunk://#diff-5c101b56000cae30fd44e2fc40e486890e07cf1c2ce5b5e76077616b2e6522f4L90-R90): Improved error messages in the `Random` function to include specific details about the nature of the errors encountered. [[1]](diffhunk://#diff-5c101b56000cae30fd44e2fc40e486890e07cf1c2ce5b5e76077616b2e6522f4L90-R90) [[2]](diffhunk://#diff-5c101b56000cae30fd44e2fc40e486890e07cf1c2ce5b5e76077616b2e6522f4L117-R117) [[3]](diffhunk://#diff-5c101b56000cae30fd44e2fc40e486890e07cf1c2ce5b5e76077616b2e6522f4L135-R135)
* [`pkg/text/service.go`](diffhunk://#diff-73dad76292fcebbae84175e3743d96422789218e2d51c99461a7cdf002cfdcfdL122-R145): Added more descriptive error messages in the `RandomVerseText` and `RandomVerseHTML` functions to better explain failures in selecting and resolving random verses.
* [`pkg/text/service.go`](diffhunk://#diff-73dad76292fcebbae84175e3743d96422789218e2d51c99461a7cdf002cfdcfdR6): Imported the `fmt` package to support the new error message formatting.