### PR TITLE
fix: missing implementation of --exclude

### DIFF
--- a/cmd/random.go
+++ b/cmd/random.go
@@ -75,6 +75,11 @@ func RunTodayRandom(cmd *cobra.Command, args []string) error {
 		opts = append(opts, ref.WithAtMost(maximumVerses))
 	}
 
+	excludeRefs := make([]string, 0, len(exclude))
+	if len(exclude) > 0 {
+		excludeRefs = append(excludeRefs, exclude...)
+	}
+
 	if excludeIndex != "" {
 		idx, err := loadIndex(excludeIndex)
 		if err != nil {
@@ -85,7 +90,12 @@ func RunTodayRandom(cmd *cobra.Command, args []string) error {
 		for _, v := range idx.Verses {
 			refs = append(refs, v.Reference)
 		}
-		opts = append(opts, ref.ExcludeReferences(refs...))
+
+		excludeRefs = append(excludeRefs, refs...)
+	}
+
+	if len(excludeRefs) > 0 {
+		opts = append(opts, ref.ExcludeReferences(excludeRefs...))
 	}
 
 	if minimumVerses > maximumVerses {

--- a/pkg/ref/random.go
+++ b/pkg/ref/random.go
@@ -130,7 +130,13 @@ func Random(opt ...RandomReferenceOption) (*Resolved, error) {
 		vs = RandomPassageFromRef(be.Ref, o.min, o.max)
 	} else {
 		if o.book != "" {
-			ex, err := Lookup(Canonical, o.book+" 1:1ffb", "")
+			b, err = o.canon.Book(o.book)
+			if err != nil {
+				return nil, fmt.Errorf("error looking up book %q: %w", o.book, err)
+			}
+
+			firstVerse := b.Verses[0]
+			ex, err := Lookup(o.canon, o.book+" "+firstVerse.Ref()+"ffb", "")
 			if err != nil {
 				return nil, fmt.Errorf("error looking up book %q: %w", o.book, err)
 			}


### PR DESCRIPTION
Fixes #42 

This does the following:
* The `--exclude` option is now implemented. Previously, the flag was defined, but was ignored entirely.
* Exclusions set by either `--exclude-index` or `--exclude` will also impact random when the `--book` option is used. Previously, the `--book` option ignored exclusions.

This pull request includes changes to improve the handling of excluded references and enhance error handling when looking up books in the `random` package. The most important changes include initializing the `excludeRefs` slice, appending to `excludeRefs` correctly, and improving error messages for book lookups.

Improvements to handling excluded references:

* [`cmd/random.go`](diffhunk://#diff-734adb146031b7bb6b795819a73053540b71647a78ea6da8d60224090e7bcf9dR78-R82): Initialized the `excludeRefs` slice and appended excluded references to it before applying the `ExcludeReferences` option. [[1]](diffhunk://#diff-734adb146031b7bb6b795819a73053540b71647a78ea6da8d60224090e7bcf9dR78-R82) [[2]](diffhunk://#diff-734adb146031b7bb6b795819a73053540b71647a78ea6da8d60224090e7bcf9dL88-R98)

Enhancements to error handling:

* [`pkg/ref/random.go`](diffhunk://#diff-5c101b56000cae30fd44e2fc40e486890e07cf1c2ce5b5e76077616b2e6522f4L133-R139): Improved error handling when looking up books by adding detailed error messages and ensuring the first verse of the book is used correctly.