### PR TITLE
chore: add maintenance skills (weekly -> deps -> dependabot-sweep)

### DIFF
--- a/.claude/skills/maintenance-deps/SKILL.md
+++ b/.claude/skills/maintenance-deps/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: maintenance-deps
+description: Run dependency maintenance for this project — executes the zed:dependabot-sweep plugin skill.
+---
+
+# Dependency Maintenance
+
+Run the full Dependabot maintenance sweep for this repository.
+
+## Steps
+
+1. Invoke the `zed:dependabot-sweep` skill and let it run to completion. It will
+   unblock stuck Dependabot PRs, merge ready PRs, fix vulnerability alerts, update
+   the changelog, and open a PR as appropriate for this repository.
+2. Report what the sweep did.

--- a/.claude/skills/maintenance-weekly/SKILL.md
+++ b/.claude/skills/maintenance-weekly/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: maintenance-weekly
+description: Run weekly maintenance for this project — currently runs dependency maintenance via maintenance-deps.
+---
+
+# Weekly Maintenance
+
+Perform the weekly maintenance pass for this repository.
+
+## Steps
+
+1. Invoke this project's `maintenance-deps` skill and let it run to completion.
+2. Report what was done.


### PR DESCRIPTION
Adds two project-level maintenance skills so this repo is swept by zed:maintenance: maintenance-deps runs zed:dependabot-sweep, and maintenance-weekly runs maintenance-deps. Thin wrappers, no project-specific customizations. Part of the post-run-#6 maintenance rollout (project zostay/2).