### PR TITLE
chore(deps): dependabot sweep 2026-06-30

### DIFF
--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Prepare for Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
           go-version: 1.25

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
           go-version: 1.25

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Test and Sanity
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
           go-version: 1.25

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+## WIP  TBD
+
+ * Upgrade dependencies.
+   - Merged Dependabot PR #83: chore(deps): bump actions/checkout from 6 to 7
+
 ## 0.9.0  2026-02-15
 
  * :computer: Added the `ref` subcommand for formatting and analyzing Bible references. This command can:


### PR DESCRIPTION
Automated Dependabot maintenance sweep.

## PRs batch-merged
- Closes #83 — chore(deps): bump actions/checkout from 6 to 7

## Vulnerabilities fixed
None (Dependabot alerts not accessible for this repo).

## Changelog
- Updated `Changes.md` with a WIP entry for this sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)