### PR TITLE
chore(deps): dependabot sweep 2026-08-03

### DIFF
--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: 1.25
       - name: Release Version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: 1.25
       - name: Release Version

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: 1.25
           cache: false

--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,7 @@
 
  * Upgrade dependencies.
    - Merged Dependabot PR #83: chore(deps): bump actions/checkout from 6 to 7
+   - Merged Dependabot PR #86: chore(deps): bump actions/setup-go from 6 to 7
 
 ## 0.9.0  2026-02-15
 


### PR DESCRIPTION
Weekly Dependabot maintenance sweep.

## PRs batch-merged

- Closes #86 — chore(deps): bump actions/setup-go from 6 to 7

## Rebases requested

None — no conflicting Dependabot PRs.

## Vulnerabilities fixed

None — no open Dependabot alerts for this repository.

## PRs punted as conflicting

None.

## Changelog

Updated `Changes.md` under the existing `WIP` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)