### PR TITLE
Release v1.0.0

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,8 +1,10 @@
-## 1.0.0  TBD
+## 1.0.0  2026-08-05
 
  * :sparkles: First stable release. The reference, text, photo, and OpenScripture.Today APIs are settled enough to commit to.
+ * :boom: Breaking Change :boom:: Now requires Go 1.25.
  * :hammer: Books without chapters (Obadiah, Philemon, 2 John, 3 John, and Jude) now resolve chapter-and-verse references naming chapter 1. Such a book has exactly one chapter, so `2 John 1:1-4` can only mean `2 John 1-4` and now resolves to it instead of failing with "expected a verse-only reference, but got chapter-and-verse". Naming any other chapter, such as `2 John 2:1`, is still an error. Since the chapter is dropped during resolution, both forms also format identically: `today ref 2jn1.1-4` outputs `2 John 1-4`.
  * :hammer: Fix: A bare relative reference following a semicolon now resolves. `Genesis 3:15-18; 5:8` previously failed with "unknown reference type: *ref.Single".
+ * :hammer: Fix: The README documented the ESV API key file as using an `access_token` key, but the code reads `access_key`, so anyone following it ended up with an empty token. The README matches the code now and also documents the Unsplash credentials that the `today ost` commands require.
  * Upgrade dependencies.
    - Merged Dependabot PR #83: chore(deps): bump actions/checkout from 6 to 7
    - Merged Dependabot PR #86: chore(deps): bump actions/setup-go from 6 to 7


### PR DESCRIPTION
Cuts **v1.0.0**, the first stable release.

## Release engineering

- `Changes.md` heading set to `## 1.0.0  2026-08-05` (US Central, matching what the workflows check).
- `cmd/version.txt` already read `1.0.0`; `today version` prints `today v1.0.0`.

## Two changelog additions

Reviewing `git log v0.9.0..master` against the changelog section turned up two shipped changes that were not recorded:

- **Go 1.25 is now the minimum.** The `go` directive moved from `1.24.5` to `1.25.0` in `defc41a` — a Dependabot `golang.org/x/oauth2` bump that carried the toolchain requirement along with it, rather than a deliberate change anyone would have thought to write down. This repo has historically marked Go version bumps as breaking (0.6.0: "Now requires Go 1.22"), and library consumers need to know, so it is recorded as such.
- **The ESV auth key documentation fix**, which is user-facing: the README told people to write `access_token` in `~/.esv.yaml` while the code reads `access_key`, so anyone following it got an empty token.

## What ships

```
 * :sparkles: First stable release. The reference, text, photo, and OpenScripture.Today APIs are settled enough to commit to.
 * :boom: Breaking Change :boom:: Now requires Go 1.25.
 * :hammer: Books without chapters now resolve chapter-and-verse references naming chapter 1.
 * :hammer: Fix: A bare relative reference following a semicolon now resolves.
 * :hammer: Fix: The README ESV auth key, plus the previously undocumented Unsplash credentials.
 * Upgrade dependencies.
```

That section becomes the published release notes verbatim.

## After merge

Tag `v1.0.0` on the merge commit, which fires `release.yaml` to build the three binaries and publish the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)