### PR TITLE
Release v1.1.0

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,4 @@
-## 1.1.0  TBD
+## 1.1.0  2026-08-05
 
  * :sparkles: `photo.Descriptor` now carries `ImageURL` and `DownloadLocation`, and the Unsplash source fills them in from the photo it already fetches. `ImageURL` is the hotlink to display the photo from, taken from the API's `urls` (preferring `raw`, which carries no size preset, and falling back to `full` then `regular`). `DownloadLocation` is the endpoint to call when the photo is actually used. Unsplash's API guidelines require consumers to display photos from these URLs rather than from a self-hosted copy, and to trigger a download only on use; keeping the two apart lets a consumer do each at the right moment. Both fields are omitted from the serialized form when empty, so existing photo metadata still loads unchanged.
 


### PR DESCRIPTION
Cuts **v1.1.0**.

## Version

Minor bump. The one change since `v1.0.0` (#92) adds two fields to an exported struct — purely additive, with no removals and no behavior change for existing callers.

## Release engineering

- `Changes.md` heading set to `## 1.1.0  2026-08-05` (US Central, matching what the workflows check).
- `cmd/version.txt` was already bumped to `1.1.0` in #92, so only the heading needed finishing. `today version` prints `today v1.1.0`.

Both workflow checks were replicated locally before pushing: exact heading match against the US Central date, and the `version.txt` substring match.

## What ships

```
 * :sparkles: photo.Descriptor now carries ImageURL and DownloadLocation, and the
   Unsplash source fills them in from the photo it already fetches.
```

That section becomes the published release notes verbatim.

The follow-up commit in #92 (`af593e0`, a doc-comment fix) is deliberately not in the notes — it corrected a comment in code that had not yet shipped, so it has no user-visible effect.

## After merge

Tag `v1.1.0` on the merge commit, which fires `release.yaml` to build the three binaries and publish the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)